### PR TITLE
fix: fixed isValidaUpdatePost rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,7 +17,6 @@ service cloud.firestore {
         allow delete: if hasAnyRole(['admin']);
     }
 
-
     function isSignedIn() {
       return request.auth != null;
     }
@@ -39,11 +38,10 @@ service cloud.firestore {
     function isValidUpdatedPost() {
       let post = request.resource.data;
       let hasRequiredFields = post.keys().hasAny(['content', 'updatedAt', 'published']);
-      let isValidContent = post.content is string && post.content.size() < 5000;
+      let isValidContent = !('content' in post) || post.content is string && post.content.size() < 5000;
 
       return hasRequiredFields && isValidContent;
     }
-    
   }
 }
 


### PR DESCRIPTION
I started the course yesterday (Nov 19th, 2021), using TypeScript
and the version 2.0.1 of '@firebase/rules-unit-testing'.

In the last firestore rule test, we only send the 'published' field as
an update. When the rule gets executed, 'published' is one of the
keys of the update, but the check right after ('post.content is 
string') fails because 'post.content' is undefined.

I was getting this error: 
```
@firebase/firestore: Firestore (9.5.0): Connection GRPC stream error. Code: 7 Message: 7 PERMISSION_DENIED: 
false for 'update' @ L5, Property content is undefined on object. for 'update' @ L16
```

The 'setup' and 'teardown' functions also changed a bit, but I was
using a different repo for the course, so those changes aren't here.

If you want to take a look at that, you can find the changes at [here](https://github.com/nikensss/cloud_functions_fireship).